### PR TITLE
Basic framework and module-actions determinents

### DIFF
--- a/dicom_deid/generate_standard_profile.py
+++ b/dicom_deid/generate_standard_profile.py
@@ -1,0 +1,32 @@
+import argparse
+from pathlib import Path
+
+from dicom_deid.standard_profile import generate_standard_profile
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Generate a standard DICOM de-identification profile"
+    )
+    parser.add_argument(
+        "--dicom-standard",
+        type=Path,
+        required=True,
+        help="Directory containing DICOM standard files",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        required=True,
+        help="Output path for the standard profile",
+    )
+    args = parser.parse_args()
+
+    generate_standard_profile(
+        dicom_standard_path=args.dicom_standard,
+        output_path=args.output,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/dicom_deid/standard_profile.py
+++ b/dicom_deid/standard_profile.py
@@ -1,0 +1,158 @@
+import json
+from collections import defaultdict
+
+
+class DICOMStandardError(ValueError):
+    pass
+
+
+class DICOMStandard:
+    """
+    Represents the DICOM standard that can be queries for properties or relations.
+
+    Raises:
+        DICOMStandardError: If inconsistencies found in relations or assumptions are
+        broken.
+    """
+
+    def __init__(
+        self,
+        *,
+        version,
+        sops,
+        module_to_attributes,
+        ciods_to_modules,
+        ciods,
+    ):
+
+        self.version = version
+
+        # Map CIOD name to CIOD id: SOPClasses and CIOD are linked via name
+        ciod_name_to_id = {ciod["name"].lower(): ciod["id"] for ciod in ciods}
+
+        # Map SOPClassUID to CIOD
+        self.__sop_id_to_ciod_id = {}
+        for entry in sops:
+            sop_id = entry["id"]
+            ciod_name = entry["ciod"].lower()
+            ciod_id = ciod_name_to_id[ciod_name]
+            if sop_id in self.__sop_id_to_ciod_id:
+                raise DICOMStandardError(
+                    f"SOP {sop_id} is already mapped to another CIOD"
+                )
+            self.__sop_id_to_ciod_id[sop_id] = ciod_id
+
+        # Map COID to modules
+        self.__ciod_id_to_module_ids = defaultdict(set)
+
+        for entry in ciods_to_modules:
+            ciod_id = entry["ciodId"]
+            module_id = entry["moduleId"]
+            self.__ciod_id_to_module_ids[ciod_id].add(module_id)
+
+        # Build module to tags, and vice vera
+        self.__module_id_to_tags = defaultdict(set)
+        self.__tag_to_module_ids = defaultdict(set)
+
+        for entry in module_to_attributes:
+            module_id = entry["moduleId"]
+            tag = entry["tag"]
+
+            self.__module_id_to_tags[module_id].add(tag)
+            self.__tag_to_module_ids[tag].add(module_id)
+
+        # Lookups
+
+        # Note: modules ARE defined multiple times in the reference
+        # We do a sanity check if the values are the same
+        self.__module_lookup = {}
+        for entry in ciods_to_modules:
+            module_id = entry["moduleId"]
+
+            # Sanity check on consistency
+            if module_id in self.__module_lookup:
+                existing = self.__module_lookup[module_id]
+                for k, v in entry.items():
+                    if k != "ciodId" and existing[k] != v:
+                        raise DICOMStandardError(
+                            f"Inconsistent definitions found for module {module_id}"
+                        )
+            else:
+                self.__module_lookup[module_id] = entry
+
+    def map_sop_to_module_ids(self, /, sop_id):
+        coid_id = self.__sop_id_to_ciod_id[sop_id]
+        return self.__ciod_id_to_module_ids[coid_id]
+
+    def map_sop_to_tags(self, /, sop_id):
+        module_ids = self.map_sop_to_module_ids(sop_id)
+
+        sop_tags = set()
+        for module_id in module_ids:
+            module_tags = self.__module_id_to_tags[module_id]
+            sop_tags.update(module_tags)
+        return sop_tags
+
+    def get_module_via_tag(self, /, tag, *, sop_id):
+        sop_module_ids = self.map_sop_to_module_ids(sop_id)
+        tag_module_ids = self.__tag_to_module_ids[tag]
+
+        matching_modules = sop_module_ids & tag_module_ids
+
+        if len(matching_modules) != 1:
+            raise DICOMStandardError(
+                f"Tag {tag} belongs to {len(matching_modules)} modules, expected 1"
+            )
+
+        module_id = matching_modules.pop()
+        return self.__module_lookup[module_id]
+
+
+class Profile:
+
+    def __init__(self):
+
+        self.__profile = {
+            "SOPClassUID": defaultdict(
+                lambda: {
+                    "tag": {},
+                },
+            )
+        }
+
+    def set_action(self, sop_id, tag, action):
+        self.__profile["SOPClassUID"][sop_id]["tag"][tag] = {
+            "action": action,
+        }
+
+    def get_unset_action_tags_in_sops(
+        self,
+    ):
+        for sop, entry in self.__profile["SOPClassUID"].items():
+            for tag, action in entry["tag"].items():
+                if action["action"] is None:
+                    yield tag, sop
+
+    def to_json(self):
+        return json.dumps(self.__profile)
+
+
+def generate_standard_profile(*, dicom_standard_path, output_path):
+    pass
+
+
+def apply_module_actions(
+    *,
+    profile: Profile,
+    dicom_standard: DICOMStandard,
+):
+
+    for tag, sop in profile.get_unset_action_tags_in_sops():
+        module = dicom_standard.get_module_via_tag(tag, sop_id=sop)
+        usage = module["usage"]
+        if usage == "U":
+            profile.set_action(sop_id=sop, tag=tag, action="X")
+        elif usage in ("M", "C"):
+            continue  # Leave it unset
+        else:
+            raise ValueError(f"Unsupported module-usage: {usage!r}")

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [flake8]
-max-line-length = 79
+max-line-length = 88
 max-complexity = 10
 
 select =
@@ -9,10 +9,13 @@ select =
     # C are complexity checks
     C
     # D are docstring checks
-    D
     E
     F
     I
     N
     W
-ignore = E203,E701
+ignore =
+    E203
+    E701
+    # Line break before binary operation: does not match Black
+    W503

--- a/tests/test_dicom_standard.py
+++ b/tests/test_dicom_standard.py
@@ -1,0 +1,145 @@
+from contextlib import nullcontext as does_not_raise
+
+import pytest
+
+from dicom_deid.standard_profile import DICOMStandard, DICOMStandardError
+
+
+def test_dicom_standard():
+    ds = DICOMStandard(
+        version="foo",
+        module_to_attributes=[
+            {
+                "moduleId": "mod0",
+                "tag": "(0000,0000)",
+            },
+            {
+                "moduleId": "mod0",
+                "tag": "(1111,1111)",
+            },
+            {
+                "moduleId": "mod1",
+                "tag": "(2222,2222)",
+            },
+        ],
+        ciods_to_modules=[
+            {
+                "ciodId": "a-name",
+                "moduleId": "mod0",
+            },
+            {
+                "ciodId": "another-name",
+                "moduleId": "mod0",
+            },
+            {
+                "ciodId": "another-name",
+                "moduleId": "mod1",
+            },
+        ],
+        sops=[
+            {
+                "id": "1.1",
+                "ciod": "A Name",
+            },
+            {
+                "id": "2.2",
+                "ciod": "Another Name",
+            },
+        ],
+        ciods=[
+            {
+                "name": "A Name",
+                "id": "a-name",
+            },
+            {
+                "name": "Another Name",
+                "id": "another-name",
+            },
+        ],
+    )
+
+    # SOP => TAGS
+    assert ds.map_sop_to_tags("1.1") == {"(0000,0000)", "(1111,1111)"}
+    assert ds.map_sop_to_tags("2.2") == {"(0000,0000)", "(1111,1111)", "(2222,2222)"}
+
+    # TAG => MODULE
+    assert ds.get_module_via_tag("(0000,0000)", sop_id="1.1")["moduleId"] == "mod0"
+
+    assert ds.get_module_via_tag("(2222,2222)", sop_id="2.2")["moduleId"] == "mod1"
+
+
+def test_dicom_standard_module_clash():
+    ds = DICOMStandard(
+        version="foo",
+        module_to_attributes=[
+            {
+                "moduleId": "mod0",
+                "tag": "(0000,0000)",
+            },
+            {
+                "moduleId": "mod1",
+                "tag": "(0000,0000)",
+            },
+        ],
+        ciods_to_modules=[
+            {
+                "ciodId": "a-name",
+                "moduleId": "mod0",
+            },
+            {
+                "ciodId": "a-name",
+                "moduleId": "mod1",
+            },
+        ],
+        sops=[
+            {
+                "id": "1.1",
+                "ciod": "A Name",
+            },
+        ],
+        ciods=[
+            {
+                "name": "A Name",
+                "id": "a-name",
+            },
+        ],
+    )
+
+    with pytest.raises(
+        DICOMStandardError, match=r"Tag \(0000,0000\) belongs to 2 modules"
+    ):
+        # Tag belongs to two different modules, in the same SOP
+        ds.get_module_via_tag("(0000,0000)", sop_id="1.1")
+
+
+@pytest.mark.parametrize(
+    "ciods_to_modules,expectation",
+    [
+        (
+            [
+                {"ciodId": "a-name", "moduleId": "mod0", "usage": "C"},
+                {"ciodId": "another-name", "moduleId": "mod0", "usage": "C"},
+            ],
+            does_not_raise(),
+        ),
+        (
+            [
+                {"ciodId": "a-name", "moduleId": "mod0", "usage": "C"},
+                {"ciodId": "another-name", "moduleId": "mod0", "usage": "U"},
+            ],
+            pytest.raises(
+                DICOMStandardError,
+                match="Inconsistent definitions found for module",
+            ),
+        ),
+    ],
+)
+def test_dicom_standard_inconsistent_modules(ciods_to_modules, expectation):
+    with expectation:
+        DICOMStandard(
+            version="foo",
+            module_to_attributes=[],
+            ciods_to_modules=ciods_to_modules,
+            sops=[],
+            ciods=[],
+        )

--- a/tests/test_standard_profile.py
+++ b/tests/test_standard_profile.py
@@ -1,0 +1,106 @@
+import json
+
+import pytest
+
+from dicom_deid.standard_profile import DICOMStandard, Profile, apply_module_actions
+
+
+@pytest.mark.parametrize(
+    "module_usage,expected_action",
+    (
+        ("U", "X"),
+        ("M", None),
+        ("C", None),
+    ),
+)
+def test_module_actions(module_usage, expected_action):
+
+    ds = DICOMStandard(
+        version="foo",
+        module_to_attributes=[
+            {
+                "moduleId": "mod0",
+                "tag": "(0000,0000)",
+            },
+            {
+                "moduleId": "mod0",
+                "tag": "(1111,1111)",
+            },
+        ],
+        ciods_to_modules=[
+            {
+                "ciodId": "a-name",
+                "moduleId": "mod0",
+                "usage": module_usage,
+            },
+        ],
+        sops=[
+            {
+                "id": "1.1",
+                "ciod": "A Name",
+            },
+        ],
+        ciods=[
+            {
+                "name": "A Name",
+                "id": "a-name",
+            },
+        ],
+    )
+    p = Profile()
+    p.set_action(sop_id="1.1", tag="(0000,0000)", action=None)
+    p.set_action(sop_id="1.1", tag="(1111,1111)", action="K")
+
+    apply_module_actions(
+        profile=p,
+        dicom_standard=ds,
+    )
+
+    json_profile = json.loads(p.to_json())
+    assert (
+        json_profile["SOPClassUID"]["1.1"]["tag"]["(0000,0000)"]["action"]
+        == expected_action
+    )
+    assert (
+        json_profile["SOPClassUID"]["1.1"]["tag"]["(1111,1111)"]["action"] == "K"
+    ), "Already set action is left alone"
+
+
+def test_unsupported_usage_module_actions():
+
+    ds = DICOMStandard(
+        version="foo",
+        module_to_attributes=[
+            {
+                "moduleId": "mod0",
+                "tag": "(0000,0000)",
+            },
+        ],
+        ciods_to_modules=[
+            {
+                "ciodId": "a-name",
+                "moduleId": "mod0",
+                "usage": "I AM UNSUPPORTED",
+            },
+        ],
+        sops=[
+            {
+                "id": "1.1",
+                "ciod": "A Name",
+            },
+        ],
+        ciods=[
+            {
+                "name": "A Name",
+                "id": "a-name",
+            },
+        ],
+    )
+    p = Profile()
+    p.set_action(sop_id="1.1", tag="(0000,0000)", action=None)
+
+    with pytest.raises(ValueError, match="Unsupported module-usage"):
+        apply_module_actions(
+            profile=p,
+            dicom_standard=ds,
+        )


### PR DESCRIPTION
Part of:
- https://github.com/DIAGNijmegen/rse-roadmap/issues/409#event-18070830739

This PR adds some basic framework (bound to change quite a lot, but wanted to sketch it none the less) and the very first action determinant based off the module usage (i.e. "U"/"M"/"C") of an attribute.

The rough, eventual flow is:

1. Create a default `Profile` off either all SOPs or a subset, set all actions to None.

2. Go through the different action determinents using the `Profile` and the `DICOMStandard`. `apply_module_actions` is the first determinent.

3. At the end: which-ever actions are still unset (i.e. `None`) these should be set manually.


## DICOMStandard considerations

I've considered to thoroughly abstract the dicom standard and be able to load it from different spec exports. I have not for the followin reasons:

- I suspect most specs will follow roughly the same data constructs as the DICOMStandard are presented in different parts and the current spec roughly follows that distiction (i.e. SOP, OIDs, attributes, modules et cetera)
- It would add complexity, a simple wrapper already allows for unit testing the standard and use dependency injection for tests.

