### PR TITLE
Add standard profile functions

### DIFF
--- a/dicom_deid/standard_profile.py
+++ b/dicom_deid/standard_profile.py
@@ -40,13 +40,13 @@ class DICOMStandard:
         macro_to_attributes = macro_to_attributes or []
 
         # Map CIOD name to CIOD id: SOPClasses and CIOD are linked via name
-        ciod_name_to_id = {ciod["name"].lower(): ciod["id"] for ciod in ciods}
+        ciod_name_to_id = {ciod["name"].casefold(): ciod["id"] for ciod in ciods}
 
         # Map SOPClassUID to CIOD
         self.__sop_id_to_ciod_id = {}
         for entry in sops:
             sop_id = entry["id"]
-            ciod_name = entry["ciod"].lower()
+            ciod_name = entry["ciod"].casefold()
             ciod_id = ciod_name_to_id[ciod_name]
             if sop_id in self.__sop_id_to_ciod_id:
                 raise DICOMStandardError(
@@ -196,7 +196,7 @@ def apply_module_actions(
 
     for tag, sop in profile.get_unset_action_tags_in_sops():
         module = dicom_standard.get_module_via_tag(tag, sop_id=sop)
-        usage = module["usage"].lower()
+        usage = module["usage"].casefold()
         if usage == "u":
             profile.set_action(
                 sop_id=sop,
@@ -216,7 +216,7 @@ def apply_retired_attribute_actions(
 ):
     for tag, sop in profile.get_unset_action_tags_in_sops():
         attribute = dicom_standard.get_attribute_via_tag(tag)
-        retired = attribute["retired"].lower()
+        retired = attribute["retired"].casefold()
         if retired == "y":
             profile.set_action(
                 sop_id=sop,
@@ -273,12 +273,12 @@ def apply_basic_dicom_deid_profile_actions(
 
     for tag, sop in profile.get_unset_action_tags_in_sops():
         conf_profile = dicom_standard.get_confidentiality_profile_via_tag(tag)
-        basic_profile_action = conf_profile["basicProfile"].lower()
+        basic_profile_action = conf_profile["basicProfile"].casefold()
 
         action = action_map.get(basic_profile_action)
         if action is None:
             attribute = dicom_standard.get_attribute_via_tag(tag)
-            attribute_type = attribute["type"].lower()
+            attribute_type = attribute["type"].casefold()
             try:
                 action = basic_profile_action_type_lookup[
                     (basic_profile_action, attribute_type)
@@ -299,7 +299,7 @@ def apply_attribute_type_actions(
 ):
     for tag, sop in profile.get_unset_action_tags_in_sops():
         attribute = dicom_standard.get_attribute_via_tag(tag)
-        attribute_type = attribute["type"].lower()
+        attribute_type = attribute["type"].casefold()
 
         action = None
 

--- a/dicom_deid/standard_profile.py
+++ b/dicom_deid/standard_profile.py
@@ -1,5 +1,6 @@
 import json
 from collections import defaultdict
+from enum import Enum
 
 
 class DICOMStandardError(ValueError):
@@ -120,7 +121,19 @@ class DICOMStandard:
         return self.__attribute_lookup[tag]
 
 
+class ActionChoices(str, Enum):
+    REMOVE = "X"
+    KEEP = "K"
+
+    REPLACE = "D"
+    REPLACE0 = "Z"
+    CLEAN = "C"
+    UID = "U"
+
+
 class Profile:
+
+    Action = ActionChoices
 
     def __init__(self):
 
@@ -163,7 +176,11 @@ def apply_module_actions(
         module = dicom_standard.get_module_via_tag(tag, sop_id=sop)
         usage = module["usage"].lower()
         if usage == "u":
-            profile.set_action(sop_id=sop, tag=tag, action="X")
+            profile.set_action(
+                sop_id=sop,
+                tag=tag,
+                action=profile.Action.REMOVE,
+            )
         elif usage in ("m", "c"):
             continue  # Leave it unset
         else:
@@ -179,7 +196,11 @@ def apply_retired_attribute_actions(
         attribute = dicom_standard.get_attribute_via_tag(tag)
         retired = attribute["retired"].lower()
         if retired == "y":
-            profile.set_action(sop_id=sop, tag=tag, action="X")
+            profile.set_action(
+                sop_id=sop,
+                tag=tag,
+                action=profile.Action.REMOVE,
+            )
         elif retired == "n":
             continue  # Leave it unset
         else:

--- a/tests/test_standard_profile.py
+++ b/tests/test_standard_profile.py
@@ -13,7 +13,7 @@ from dicom_deid.standard_profile import (
 @pytest.mark.parametrize(
     "module_usage,expected_action",
     (
-        ("U", "X"),
+        ("U", Profile.Action.REMOVE),
         ("M", None),
         ("C", None),
     ),
@@ -54,7 +54,7 @@ def test_module_actions(module_usage, expected_action):
     )
     p = Profile()
     p.set_action(sop_id="1.1", tag="(0000,0000)", action=None)
-    p.set_action(sop_id="1.1", tag="(1111,1111)", action="K")
+    p.set_action(sop_id="1.1", tag="(1111,1111)", action=p.Action.KEEP)
 
     apply_module_actions(
         profile=p,
@@ -67,7 +67,8 @@ def test_module_actions(module_usage, expected_action):
         == expected_action
     )
     assert (
-        json_profile["SOPClassUID"]["1.1"]["tag"]["(1111,1111)"]["action"] == "K"
+        json_profile["SOPClassUID"]["1.1"]["tag"]["(1111,1111)"]["action"]
+        == p.Action.KEEP
     ), "Already set action is left alone"
 
 
@@ -114,7 +115,7 @@ def test_unsupported_usage_module_actions():
 @pytest.mark.parametrize(
     "retired_state,expected_action",
     (
-        ("Y", "X"),
+        ("Y", Profile.Action.REMOVE),
         ("N", None),
     ),
 )
@@ -158,7 +159,7 @@ def test_retired_attributes(retired_state, expected_action):
     )
     p = Profile()
     p.set_action(sop_id="1.1", tag="(0000,0000)", action=None)
-    p.set_action(sop_id="1.1", tag="(1111,1111)", action="K")
+    p.set_action(sop_id="1.1", tag="(1111,1111)", action=p.Action.KEEP)
 
     apply_retired_attribute_actions(
         profile=p,
@@ -171,7 +172,8 @@ def test_retired_attributes(retired_state, expected_action):
         == expected_action
     )
     assert (
-        json_profile["SOPClassUID"]["1.1"]["tag"]["(1111,1111)"]["action"] == "K"
+        json_profile["SOPClassUID"]["1.1"]["tag"]["(1111,1111)"]["action"]
+        == p.Action.KEEP
     ), "Already set action is left alone"
 
 

--- a/tests/test_standard_profile.py
+++ b/tests/test_standard_profile.py
@@ -1,10 +1,12 @@
 import json
+from contextlib import nullcontext as does_not_raise
 
 import pytest
 
 from dicom_deid.standard_profile import (
     DICOMStandard,
     Profile,
+    apply_basic_dicom_deid_profile,
     apply_module_actions,
     apply_retired_attribute_actions,
 )
@@ -220,6 +222,268 @@ def test_unknown_restired_state():
 
     with pytest.raises(ValueError, match="Unsupported attribute retired"):
         apply_retired_attribute_actions(
+            profile=p,
+            dicom_standard=ds,
+        )
+
+
+@pytest.mark.parametrize(
+    "basic_profile_value,expected_action",
+    (
+        ("D", Profile.Action.REPLACE),
+        ("Z", Profile.Action.REPLACE0),
+        ("X", Profile.Action.REMOVE),
+        ("K", Profile.Action.KEEP),
+        ("C", Profile.Action.CLEAN),
+        ("U", Profile.Action.UID),
+    ),
+)
+def test_basic_dicom_deid_profile_actions(basic_profile_value, expected_action):
+    ds = DICOMStandard(
+        version="foo",
+        attributes=[
+            {
+                "tag": "(0000,0000)",
+                "retired": "I AM UNKOWN",
+            },
+        ],
+        module_to_attributes=[
+            {
+                "moduleId": "mod0",
+                "tag": "(0000,0000)",
+            },
+            {
+                "moduleId": "mod0",
+                "tag": "(1111,1111)",
+            },
+        ],
+        ciods_to_modules=[
+            {
+                "ciodId": "a-name",
+                "moduleId": "mod0",
+            },
+        ],
+        sops=[
+            {
+                "id": "1.1",
+                "ciod": "A Name",
+            },
+        ],
+        ciods=[
+            {
+                "name": "A Name",
+                "id": "a-name",
+            },
+        ],
+        confidentiality_profile_attributes=[
+            {
+                "tag": "(0000,0000)",
+                "basicProfile": basic_profile_value,
+            },
+        ],
+    )
+    p = Profile()
+    p.set_action(sop_id="1.1", tag="(0000,0000)", action=None)
+    p.set_action(sop_id="1.1", tag="(1111,1111)", action=p.Action.KEEP)
+
+    apply_basic_dicom_deid_profile(
+        profile=p,
+        dicom_standard=ds,
+    )
+
+    json_profile = json.loads(p.to_json())
+    assert (
+        json_profile["SOPClassUID"]["1.1"]["tag"]["(0000,0000)"]["action"]
+        == expected_action
+    )
+    assert (
+        json_profile["SOPClassUID"]["1.1"]["tag"]["(1111,1111)"]["action"]
+        == p.Action.KEEP
+    ), "Already set action is left alone"
+
+
+@pytest.mark.parametrize(
+    "basic_profile_value,type_value,expected_action",
+    [
+        # Z/D
+        ("Z/D", "1", Profile.Action.REPLACE),
+        ("Z/D", "1C", Profile.Action.REPLACE),
+        ("Z/D", "2", Profile.Action.REPLACE0),
+        ("Z/D", "2C", Profile.Action.REPLACE0),
+        ("Z/D", "3", Profile.Action.REMOVE),
+        # X/Z
+        ("X/Z", "1", Profile.Action.REPLACE),
+        ("X/Z", "1C", Profile.Action.REPLACE),
+        ("X/Z", "2", Profile.Action.REPLACE0),
+        ("X/Z", "2C", Profile.Action.REPLACE0),
+        ("X/Z", "3", Profile.Action.REMOVE),
+        # X/D
+        ("X/D", "1", Profile.Action.REPLACE),
+        ("X/D", "1C", Profile.Action.REPLACE),
+        ("X/D", "2", Profile.Action.REPLACE0),
+        ("X/D", "2C", Profile.Action.REPLACE0),
+        ("X/D", "3", Profile.Action.REMOVE),
+        # "X/Z/D"
+        ("X/Z/D", "1", Profile.Action.REPLACE),
+        ("X/Z/D", "1C", Profile.Action.REPLACE),
+        ("X/Z/D", "2", Profile.Action.REPLACE0),
+        ("X/Z/D", "2C", Profile.Action.REPLACE0),
+        ("X/Z/D", "3", Profile.Action.REMOVE),
+        # X/Z/U
+        ("X/Z/U*", "1", Profile.Action.UID),
+        ("X/Z/U*", "1C", Profile.Action.UID),
+        ("X/Z/U*", "2", Profile.Action.REPLACE0),
+        ("X/Z/U*", "2C", Profile.Action.REPLACE0),
+        ("X/Z/U*", "3", Profile.Action.REMOVE),
+    ],
+)
+def test_basic_dicom_deid_profile_actions_types(
+    basic_profile_value, type_value, expected_action
+):
+    ds = DICOMStandard(
+        version="foo",
+        macro_to_attributes=[
+            {
+                "tag": "(0000,0000)",
+                "type": type_value,
+            },
+        ],
+        attributes=[
+            {
+                "tag": "(0000,0000)",
+            },
+        ],
+        module_to_attributes=[
+            {
+                "moduleId": "mod0",
+                "tag": "(0000,0000)",
+            },
+            {
+                "moduleId": "mod0",
+                "tag": "(1111,1111)",
+            },
+        ],
+        ciods_to_modules=[
+            {
+                "ciodId": "a-name",
+                "moduleId": "mod0",
+            },
+        ],
+        sops=[
+            {
+                "id": "1.1",
+                "ciod": "A Name",
+            },
+        ],
+        ciods=[
+            {
+                "name": "A Name",
+                "id": "a-name",
+            },
+        ],
+        confidentiality_profile_attributes=[
+            {
+                "tag": "(0000,0000)",
+                "basicProfile": basic_profile_value,
+            },
+        ],
+    )
+    p = Profile()
+    p.set_action(sop_id="1.1", tag="(0000,0000)", action=None)
+    p.set_action(sop_id="1.1", tag="(1111,1111)", action=p.Action.KEEP)
+
+    apply_basic_dicom_deid_profile(
+        profile=p,
+        dicom_standard=ds,
+    )
+
+    json_profile = json.loads(p.to_json())
+    assert (
+        json_profile["SOPClassUID"]["1.1"]["tag"]["(0000,0000)"]["action"]
+        == expected_action
+    )
+    assert (
+        json_profile["SOPClassUID"]["1.1"]["tag"]["(1111,1111)"]["action"]
+        == p.Action.KEEP
+    ), "Already set action is left alone"
+
+
+@pytest.mark.parametrize(
+    "basic_profile_value,type_value,expectation",
+    [
+        (
+            "Z/D",
+            "1",
+            does_not_raise(),
+        ),
+        (
+            "I DO NOT EXIST",
+            "1",
+            pytest.raises(ValueError, match="Unsupported confidentiality action"),
+        ),
+        (
+            "Z/D",
+            "I DO NOT EXIST",
+            pytest.raises(ValueError, match="Unsupported confidentiality action"),
+        ),
+    ],
+)
+def test_basic_dicom_deid_unsupported_type_and_basic_profile(
+    basic_profile_value, type_value, expectation
+):
+    ds = DICOMStandard(
+        version="foo",
+        macro_to_attributes=[
+            {
+                "tag": "(0000,0000)",
+                "type": type_value,
+            },
+        ],
+        attributes=[
+            {
+                "tag": "(0000,0000)",
+            },
+        ],
+        module_to_attributes=[
+            {
+                "moduleId": "mod0",
+                "tag": "(0000,0000)",
+            },
+            {
+                "moduleId": "mod0",
+                "tag": "(1111,1111)",
+            },
+        ],
+        ciods_to_modules=[
+            {
+                "ciodId": "a-name",
+                "moduleId": "mod0",
+            },
+        ],
+        sops=[
+            {
+                "id": "1.1",
+                "ciod": "A Name",
+            },
+        ],
+        ciods=[
+            {
+                "name": "A Name",
+                "id": "a-name",
+            },
+        ],
+        confidentiality_profile_attributes=[
+            {
+                "tag": "(0000,0000)",
+                "basicProfile": basic_profile_value,
+            },
+        ],
+    )
+    p = Profile()
+    p.set_action(sop_id="1.1", tag="(0000,0000)", action=None)
+
+    with expectation:
+        apply_basic_dicom_deid_profile(
             profile=p,
             dicom_standard=ds,
         )

--- a/tests/test_standard_profile.py
+++ b/tests/test_standard_profile.py
@@ -2,7 +2,12 @@ import json
 
 import pytest
 
-from dicom_deid.standard_profile import DICOMStandard, Profile, apply_module_actions
+from dicom_deid.standard_profile import (
+    DICOMStandard,
+    Profile,
+    apply_module_actions,
+    apply_retired_attribute_actions,
+)
 
 
 @pytest.mark.parametrize(
@@ -99,8 +104,120 @@ def test_unsupported_usage_module_actions():
     p = Profile()
     p.set_action(sop_id="1.1", tag="(0000,0000)", action=None)
 
-    with pytest.raises(ValueError, match="Unsupported module-usage"):
+    with pytest.raises(ValueError, match="Unsupported module usage"):
         apply_module_actions(
+            profile=p,
+            dicom_standard=ds,
+        )
+
+
+@pytest.mark.parametrize(
+    "retired_state,expected_action",
+    (
+        ("Y", "X"),
+        ("N", None),
+    ),
+)
+def test_retired_attributes(retired_state, expected_action):
+    ds = DICOMStandard(
+        version="foo",
+        attributes=[
+            {
+                "tag": "(0000,0000)",
+                "retired": retired_state,
+            },
+        ],
+        module_to_attributes=[
+            {
+                "moduleId": "mod0",
+                "tag": "(0000,0000)",
+            },
+            {
+                "moduleId": "mod0",
+                "tag": "(1111,1111)",
+            },
+        ],
+        ciods_to_modules=[
+            {
+                "ciodId": "a-name",
+                "moduleId": "mod0",
+            },
+        ],
+        sops=[
+            {
+                "id": "1.1",
+                "ciod": "A Name",
+            },
+        ],
+        ciods=[
+            {
+                "name": "A Name",
+                "id": "a-name",
+            },
+        ],
+    )
+    p = Profile()
+    p.set_action(sop_id="1.1", tag="(0000,0000)", action=None)
+    p.set_action(sop_id="1.1", tag="(1111,1111)", action="K")
+
+    apply_retired_attribute_actions(
+        profile=p,
+        dicom_standard=ds,
+    )
+
+    json_profile = json.loads(p.to_json())
+    assert (
+        json_profile["SOPClassUID"]["1.1"]["tag"]["(0000,0000)"]["action"]
+        == expected_action
+    )
+    assert (
+        json_profile["SOPClassUID"]["1.1"]["tag"]["(1111,1111)"]["action"] == "K"
+    ), "Already set action is left alone"
+
+
+def test_unknown_restired_state():
+    ds = DICOMStandard(
+        version="foo",
+        attributes=[
+            {
+                "tag": "(0000,0000)",
+                "retired": "I AM UNKOWN",
+            },
+        ],
+        module_to_attributes=[
+            {
+                "moduleId": "mod0",
+                "tag": "(0000,0000)",
+            },
+            {
+                "moduleId": "mod0",
+                "tag": "(1111,1111)",
+            },
+        ],
+        ciods_to_modules=[
+            {
+                "ciodId": "a-name",
+                "moduleId": "mod0",
+            },
+        ],
+        sops=[
+            {
+                "id": "1.1",
+                "ciod": "A Name",
+            },
+        ],
+        ciods=[
+            {
+                "name": "A Name",
+                "id": "a-name",
+            },
+        ],
+    )
+    p = Profile()
+    p.set_action(sop_id="1.1", tag="(0000,0000)", action=None)
+
+    with pytest.raises(ValueError, match="Unsupported attribute retired"):
+        apply_retired_attribute_actions(
             profile=p,
             dicom_standard=ds,
         )


### PR DESCRIPTION
(Going to use the 'Profile' for now. I actually think that 'Procedure' makes more sense as it is a descriptive step-by-step  in nature than a profile which seems to describe.)

Part of the pitch:
- https://github.com/DIAGNijmegen/rse-roadmap/issues/409#event-18070830739

This PR adds the final 4 decisions that build the standard profile:
- `apply_module_actions` (already on `main`)
- `apply_retired_attribute_actions`
- `apply_basic_dicom_deid_profile_actions`
- `apply_attribute_type_actions`

Follow up would be to see what these actions result in for the CT image SOP.